### PR TITLE
Enabling userid authentication through the UAA Middleware and Url-encode the username/password credentials to accept special characters in them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.1.0',
 
     description="IBM's UAA keystone middleware",
     long_description=long_description,


### PR DESCRIPTION
By this change, the UAA Middleware supports
1. userid to username conversion to enable authentication through userid/password.
2. special characters are accepted in the username and password credentials as they are now url-encoded and parsed for authentication.